### PR TITLE
Serialize Nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,25 @@ class SomeController
 }
 ```
 
+#### `NodeNormalizer`
+
+If using `symfony/serializer` in your app, a `NodeNormalizer` is auto-registered/configured and can
+normalizer/denormalize `File|Image|Directory` nodes. Nodes are normalized into a string in the format:
+`<filesystem-name>://<path/to/node>`:
+
+```php
+use Zenstruck\Filesystem\Node\File;
+
+/** @var \Zenstruck\Filesystem $filesystem */
+/** @var \Symfony\Component\Serializer\Serializer $serializer */
+
+$file = $filesystem->file('some/file.txt');
+
+$encoded = $serializer->serialize($file, 'json'); // "public://some/file.txt" (json encoded)
+
+$decoded = $serializer->decode($encoded, File::class); // File
+```
+
 #### Testing
 
 By default, in your `test` environment, your defined filesystem adapters are swapped with local adapters whose

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ $checksum = $file->checksum(); // Zenstruck\Filesystem\Node\File\Checksum
 $checksum->equals($anotherChecksum); // bool
 ```
 
+> **Note**: `File` should be considered _final_ and is not meant to be extended.
+
 #### `Image`
 
 The `Image` node extends `File` so all it's methods are available.
@@ -220,6 +222,8 @@ $image->isLandscape(); // bool
 $image->isPortrait(); // bool
 $image->isSquare(); // bool
 ```
+
+> **Note**: `Image` should be considered _final_ and is not meant to be extended.
 
 #### `Directory`
 
@@ -279,6 +283,8 @@ foreach ($filtered as $file) {
     // $file = Zenstruck\Filesystem\Node\File
 }
 ```
+
+> **Note**: `Directory` should be considered _final_ and is not meant to be extended.
 
 ## Filesystems
 
@@ -1119,6 +1125,9 @@ $user->profileImage = new PendingFile('/new/image.jpg');
 
 $em->flush(); // auto-removes old image and saves the new
 ```
+
+> **Note**: `PendingFile` is not meant to be used as a property typehint on your entity's. Be sure to use `File`
+> as the typehint.
 
 ##### Namer's
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/mime": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^6.0",
+        "symfony/serializer": "^5.4|^6.0",
         "symfony/twig-bundle": "^5.4|^6.0",
         "symfony/validator": "^5.4|^6.0",
         "symfony/var-dumper": "^5.4|^6.0",

--- a/src/Filesystem/Adapter/Operator.php
+++ b/src/Filesystem/Adapter/Operator.php
@@ -34,9 +34,14 @@ final class Operator extends Filesystem implements FileChecksum, ModifyFile, Fil
      * @param GlobalConfig|array<string,mixed> $config
      * @param Features                         $features
      */
-    public function __construct(private FilesystemAdapter $adapter, private array $config = [], private iterable|ContainerInterface $features = [])
+    public function __construct(private FilesystemAdapter $adapter, private string $name, private array $config = [], private iterable|ContainerInterface $features = [])
     {
         parent::__construct($adapter, $config, $this->normalizer = $config['path_normalizer'] ?? new WhitespacePathNormalizer());
+    }
+
+    public function serialize(string $path): string
+    {
+        return "{$this->name}://{$path}";
     }
 
     public function fileAttributesFor(string $path): FileAttributes

--- a/src/Filesystem/AdapterFilesystem.php
+++ b/src/Filesystem/AdapterFilesystem.php
@@ -49,8 +49,8 @@ final class AdapterFilesystem implements Filesystem
             $adapter = new LocalAdapter($adapter);
         }
 
-        $this->operator = new Operator($adapter, $config, $features);
         $this->name = $this->config['name'] ?? 'default';
+        $this->operator = new Operator($adapter, $this->name, $config, $features);
         $this->last = new \LogicException('No operations have been performed.');
     }
 

--- a/src/Filesystem/Bridge/Symfony/DependencyInjection/ZenstruckFilesystemExtension.php
+++ b/src/Filesystem/Bridge/Symfony/DependencyInjection/ZenstruckFilesystemExtension.php
@@ -29,6 +29,7 @@ use Zenstruck\Filesystem\Bridge\Doctrine\Persistence\NodeConfigProvider;
 use Zenstruck\Filesystem\Bridge\Doctrine\Persistence\ORMNodeConfigProvider;
 use Zenstruck\Filesystem\Bridge\Symfony\HttpKernel\FilesystemDataCollector;
 use Zenstruck\Filesystem\Bridge\Symfony\Routing\RouteFileUrlFeature;
+use Zenstruck\Filesystem\Bridge\Symfony\Serializer\NodeNormalizer;
 use Zenstruck\Filesystem\Bridge\Twig\ObjectNodeLoaderExtension;
 use Zenstruck\Filesystem\Feature\FileUrl;
 use Zenstruck\Filesystem\Feature\FileUrl\PrefixFileUrlFeature;
@@ -51,6 +52,11 @@ final class ZenstruckFilesystemExtension extends ConfigurableExtension
         }
 
         $container->register('.zenstruck_filesystem.adapter_factory', AdapterFactory::class);
+
+        $container->register('.zenstruck_filesystem.node_normalizer', NodeNormalizer::class)
+            ->addTag('serializer.normalizer')
+            ->addTag('container.service_subscriber')
+        ;
 
         if ($container->getParameter('kernel.debug')) {
             $container->register('.zenstruck_filesystem.data_collector', FilesystemDataCollector::class)

--- a/src/Filesystem/Bridge/Symfony/Serializer/NodeNormalizer.php
+++ b/src/Filesystem/Bridge/Symfony/Serializer/NodeNormalizer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Zenstruck\Filesystem\Bridge\Symfony\Serializer;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Zenstruck\Filesystem\MultiFilesystem;
+use Zenstruck\Filesystem\Node;
+use Zenstruck\Filesystem\Node\Directory;
+use Zenstruck\Filesystem\Node\File;
+use Zenstruck\Filesystem\Node\File\Image;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class NodeNormalizer implements NormalizerInterface, DenormalizerInterface, ServiceSubscriberInterface, CacheableSupportsMethodInterface
+{
+    public function __construct(private ContainerInterface $container)
+    {
+    }
+
+    /**
+     * @param Node    $object
+     * @param mixed[] $context
+     */
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
+    {
+        return $object->serialize();
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    {
+        return $data instanceof Node;
+    }
+
+    /**
+     * @param string                                   $data
+     * @param class-string<File|Image|Directory<Node>> $type
+     * @param mixed[]                                  $context
+     *
+     * @return File|Image|Directory<Node>
+     */
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): File|Image|Directory
+    {
+        if (!\is_string($data)) {
+            throw NotNormalizableValueException::createForUnexpectedDataType('The data must be a string.', $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
+        }
+
+        return $type::unserialize($data, $this->container->get(MultiFilesystem::class));
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    {
+        return \in_array($type, [File::class, Image::class, Directory::class], true);
+    }
+
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [MultiFilesystem::class];
+    }
+}

--- a/src/Filesystem/Bridge/Symfony/Serializer/NodeNormalizer.php
+++ b/src/Filesystem/Bridge/Symfony/Serializer/NodeNormalizer.php
@@ -33,7 +33,10 @@ final class NodeNormalizer implements NormalizerInterface, DenormalizerInterface
         return $object->serialize();
     }
 
-    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    /**
+     * @param mixed[] $context
+     */
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Node;
     }
@@ -54,7 +57,10 @@ final class NodeNormalizer implements NormalizerInterface, DenormalizerInterface
         return $type::unserialize($data, $this->container->get(MultiFilesystem::class));
     }
 
-    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
+    /**
+     * @param mixed[] $context
+     */
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return \in_array($type, [File::class, Image::class, Directory::class], true);
     }

--- a/src/Filesystem/Node.php
+++ b/src/Filesystem/Node.php
@@ -82,4 +82,11 @@ interface Node extends \Stringable
      * @param ImageConfig $config
      */
     public function isImage(array $config = []): bool;
+
+    public function serialize(): string;
+
+    /**
+     * @return File|Image|Directory<Node>
+     */
+    public static function unserialize(string $serialized, MultiFilesystem $filesystem): File|Image|Directory;
 }

--- a/src/Filesystem/Node/Directory.php
+++ b/src/Filesystem/Node/Directory.php
@@ -8,6 +8,7 @@ use Symfony\Component\Finder\Iterator\LazyIterator;
 use Zenstruck\Dimension\Information;
 use Zenstruck\Filesystem\Adapter\Operator;
 use Zenstruck\Filesystem\ArchiveFile;
+use Zenstruck\Filesystem\MultiFilesystem;
 use Zenstruck\Filesystem\Node;
 use Zenstruck\Filesystem\Node\Directory\Filter\MatchingNameFilter;
 use Zenstruck\Filesystem\Node\Directory\Filter\MatchingPathFilter;
@@ -24,7 +25,7 @@ use Zenstruck\Filesystem\Node\Directory\Filter\MatchingPathFilter;
 class Directory implements Node, \IteratorAggregate
 {
     use IsNode {
-        __construct as traitConstruct;
+        __construct as private traitConstruct;
     }
 
     private bool $recursive = false;
@@ -50,6 +51,14 @@ class Directory implements Node, \IteratorAggregate
     public function __construct(DirectoryAttributes $attributes, Operator $operator)
     {
         $this->traitConstruct($attributes, $operator);
+    }
+
+    /**
+     * @return self<Node>
+     */
+    final public static function unserialize(string $serialized, MultiFilesystem $filesystem): self
+    {
+        return $filesystem->directory($serialized);
     }
 
     final public function mimeType(): string

--- a/src/Filesystem/Node/File.php
+++ b/src/Filesystem/Node/File.php
@@ -7,6 +7,7 @@ use Zenstruck\Dimension\Information;
 use Zenstruck\Filesystem\Adapter\Operator;
 use Zenstruck\Filesystem\Exception\UnsupportedFeature;
 use Zenstruck\Filesystem\Feature\FileUrl;
+use Zenstruck\Filesystem\MultiFilesystem;
 use Zenstruck\Filesystem\Node;
 use Zenstruck\Filesystem\Node\File\Checksum;
 use Zenstruck\Filesystem\TempFile;
@@ -18,8 +19,8 @@ use Zenstruck\Uri;
 class File implements Node
 {
     use IsNode {
-        __construct as traitConstruct;
-        refresh as traitRefresh;
+        __construct as private traitConstruct;
+        refresh as private traitRefresh;
     }
 
     protected const MULTI_EXTENSIONS = ['gz' => 'tar.gz', 'bz2' => 'tar.bz2'];
@@ -48,6 +49,11 @@ class File implements Node
         if ($mimeType = $attributes->mimeType()) {
             $this->mimeType = $mimeType;
         }
+    }
+
+    public static function unserialize(string $serialized, MultiFilesystem $filesystem): self
+    {
+        return $filesystem->file($serialized);
     }
 
     /**

--- a/src/Filesystem/Node/File/Image.php
+++ b/src/Filesystem/Node/File/Image.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Filesystem\Node\File;
 
 use League\Flysystem\UnableToRetrieveMetadata;
+use Zenstruck\Filesystem\MultiFilesystem;
 use Zenstruck\Filesystem\Node\File;
 
 /**
@@ -18,6 +19,11 @@ class Image extends File
     protected function __construct(string $path)
     {
         $this->path = $path;
+    }
+
+    final public static function unserialize(string $serialized, MultiFilesystem $filesystem): self
+    {
+        return parent::unserialize($serialized, $filesystem)->ensureImage();
     }
 
     final public function height(): int

--- a/src/Filesystem/Node/File/PendingFile.php
+++ b/src/Filesystem/Node/File/PendingFile.php
@@ -5,6 +5,7 @@ namespace Zenstruck\Filesystem\Node\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Zenstruck\Filesystem\Adapter\Operator;
 use Zenstruck\Filesystem\AdapterFilesystem;
+use Zenstruck\Filesystem\MultiFilesystem;
 use Zenstruck\Filesystem\Node\File;
 
 /**
@@ -25,6 +26,16 @@ final class PendingFile extends File
         $this->file = \is_string($file) ? new \SplFileInfo($file) : $file;
         $this->path = $this->file->getFilename();
         $this->config = $config;
+    }
+
+    public static function unserialize(string $serialized, MultiFilesystem $filesystem): File
+    {
+        throw new \BadMethodCallException(\sprintf('%s cannot be unserialized.', self::class));
+    }
+
+    public function serialize(): string
+    {
+        throw new \BadMethodCallException(\sprintf('%s cannot be serialized.', self::class));
     }
 
     /**

--- a/src/Filesystem/Node/IsNode.php
+++ b/src/Filesystem/Node/IsNode.php
@@ -37,7 +37,7 @@ trait IsNode
         return $this->path;
     }
 
-    final public function serialize(): string
+    public function serialize(): string
     {
         return $this->operator()->serialize($this->path);
     }

--- a/src/Filesystem/Node/IsNode.php
+++ b/src/Filesystem/Node/IsNode.php
@@ -37,6 +37,11 @@ trait IsNode
         return $this->path;
     }
 
+    final public function serialize(): string
+    {
+        return $this->operator()->serialize($this->path);
+    }
+
     final public function path(): string
     {
         return $this->path;

--- a/tests/Bridge/Symfony/Serializer/NodeNormalizerTest.php
+++ b/tests/Bridge/Symfony/Serializer/NodeNormalizerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Zenstruck\Filesystem\Tests\Bridge\Symfony\Serializer;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Serializer\Serializer;
+use Zenstruck\Filesystem\Node\File;
+use Zenstruck\Filesystem\Test\InteractsWithFilesystem;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class NodeNormalizerTest extends KernelTestCase
+{
+    use InteractsWithFilesystem;
+
+    /**
+     * @test
+     */
+    public function can_serialize_and_deserialize_nodes(): void
+    {
+        /** @var Serializer $serializer */
+        $serializer = self::getContainer()->get('serializer');
+
+        $file = $this->filesystem()->write('sub/file.txt', 'content')->last();
+        $file = $serializer->serialize($file, 'json');
+
+        $this->assertSame(\json_encode('public://sub/file.txt'), $file);
+
+        $file = $serializer->deserialize($file, File::class, 'json');
+
+        $this->assertInstanceOf(File::class, $file);
+        $this->assertSame('sub/file.txt', $file->path());
+    }
+}

--- a/tests/Node/File/LazyFileTest.php
+++ b/tests/Node/File/LazyFileTest.php
@@ -3,7 +3,6 @@
 namespace Zenstruck\Filesystem\Tests\Node\File;
 
 use PHPUnit\Framework\TestCase;
-use Zenstruck\Filesystem\Node\File;
 use Zenstruck\Filesystem\Node\File\LazyFile;
 use Zenstruck\Filesystem\Node\LazyNode;
 use Zenstruck\Filesystem\Test\InteractsWithFilesystem;
@@ -11,7 +10,7 @@ use Zenstruck\Filesystem\Test\InteractsWithFilesystem;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-class LazyNodeTest extends TestCase
+class LazyFileTest extends TestCase
 {
     use InteractsWithFilesystem;
 
@@ -45,7 +44,7 @@ class LazyNodeTest extends TestCase
         $node->lastModified();
     }
 
-    protected function createNode(string $path): LazyNode|File
+    protected function createNode(string $path): LazyNode
     {
         return new LazyFile($path);
     }

--- a/tests/Node/File/LazyImageTest.php
+++ b/tests/Node/File/LazyImageTest.php
@@ -2,14 +2,13 @@
 
 namespace Zenstruck\Filesystem\Tests\Node\File;
 
-use Zenstruck\Filesystem\Node\File;
 use Zenstruck\Filesystem\Node\File\LazyImage;
 use Zenstruck\Filesystem\Node\LazyNode;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class LazyImageTest extends LazyNodeTest
+final class LazyImageTest extends LazyFileTest
 {
     /**
      * @test
@@ -19,7 +18,7 @@ final class LazyImageTest extends LazyNodeTest
         $this->assertTrue($this->createNode('foo/bar.txt')->isImage());
     }
 
-    protected function createNode(string $path): LazyNode|File
+    protected function createNode(string $path): LazyNode
     {
         return new LazyImage($path);
     }

--- a/tests/Node/File/PendingFileTest.php
+++ b/tests/Node/File/PendingFileTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Zenstruck\Filesystem\Tests\Node\File;
+
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Filesystem\AdapterFilesystem;
+use Zenstruck\Filesystem\MultiFilesystem;
+use Zenstruck\Filesystem\Node\File\PendingFile;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class PendingFileTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function cannot_be_serialized(): void
+    {
+        $file = new PendingFile(__FILE__);
+
+        $this->expectException(\BadMethodCallException::class);
+
+        $file->serialize();
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_be_unserialized(): void
+    {
+        $filesystem = new MultiFilesystem([
+            new AdapterFilesystem(new InMemoryFilesystemAdapter()),
+        ]);
+
+        $this->expectException(\BadMethodCallException::class);
+
+        PendingFile::unserialize('some string', $filesystem);
+    }
+}

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Zenstruck\Filesystem\Tests;
+
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Filesystem\AdapterFilesystem;
+use Zenstruck\Filesystem\MultiFilesystem;
+use Zenstruck\Filesystem\Node\Directory;
+use Zenstruck\Filesystem\Node\File;
+use Zenstruck\Filesystem\Node\File\Image;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class NodeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_serialize_and_unserialize_nodes(): void
+    {
+        $filesystem = new MultiFilesystem([
+            'first' => new AdapterFilesystem(new InMemoryFilesystemAdapter(), ['name' => 'first']),
+            'second' => new AdapterFilesystem(new InMemoryFilesystemAdapter(), ['name' => 'second']),
+        ]);
+
+        $filesystem
+            ->write('first://sub/file.txt', 'content')
+            ->write('second://sub/file.png', 'content')
+        ;
+
+        $file = $filesystem->node('first://sub/file.txt')->serialize();
+        $image = $filesystem->node('second://sub/file.png')->serialize();
+        $dir = $filesystem->node('first://sub')->serialize();
+
+        $this->assertSame('first://sub/file.txt', $file);
+        $this->assertSame('second://sub/file.png', $image);
+        $this->assertSame('first://sub', $dir);
+
+        $file = File::unserialize($file, $filesystem);
+        $image = Image::unserialize($image, $filesystem);
+        $dir = Directory::unserialize($dir, $filesystem);
+
+        $this->assertSame('sub/file.txt', $file->path());
+        $this->assertSame('sub/file.png', $image->path());
+        $this->assertSame('sub', $dir->path());
+    }
+}


### PR DESCRIPTION
Possibly fixes #47.

Not sure I like how this tightly couples `MultiFilesystem` to `Node::serialize()/unserialize()` but not sure how to avoid completely.

I did discover that when using `MultiFilesystem` you could key the filesystems with a different name than `Filesystem::name()` which would lead to unexpected things. I'll attempt to enforce in #50.

The `Node::serialize()` is required (so we can prefix the path with the filesystem's name). Not sure about `Node::unserialize()` (this could be handled within `NodeNormalizer`)