### PR TITLE
POC for image transformer

### DIFF
--- a/src/Filesystem/ImageTransformer/Driver.php
+++ b/src/Filesystem/ImageTransformer/Driver.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Zenstruck\Filesystem\ImageTransformer;
+
+use Zenstruck\Filesystem\Adapter\Operator;
+use Zenstruck\Filesystem\Node\File\Image;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+interface Driver
+{
+    public function loadFromImage(Image $image): mixed;
+
+    public function getContents(mixed $resource): mixed;
+}

--- a/src/Filesystem/ImageTransformer/Driver.php
+++ b/src/Filesystem/ImageTransformer/Driver.php
@@ -1,9 +1,7 @@
 <?php
-declare(strict_types=1);
 
 namespace Zenstruck\Filesystem\ImageTransformer;
 
-use Zenstruck\Filesystem\Adapter\Operator;
 use Zenstruck\Filesystem\Node\File\Image;
 
 /**

--- a/src/Filesystem/ImageTransformer/Driver/GDDriver.php
+++ b/src/Filesystem/ImageTransformer/Driver/GDDriver.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Zenstruck\Filesystem\ImageTransformer\Driver;
+
+use BadMethodCallException;
+use Exception;
+use GdImage;
+use Zenstruck\Filesystem\ImageTransformer\Driver;
+use Zenstruck\Filesystem\Node\File\Image;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+class GDDriver implements Driver
+{
+    /**
+     * @throws Exception
+     */
+    public function loadFromImage(Image $image): GdImage
+    {
+        // TODO: throw something meaningful on fail
+        return imagecreatefromstring($image->contents()) ?: throw new Exception();
+    }
+
+    public function getContents(mixed $resource): mixed
+    {
+        if (!$resource instanceof GdImage) {
+            throw new BadMethodCallException(sprintf("Wrong data type returned from tranformation. %s was expected, got %s", GdImage::class, is_object($resource) ? $resource::class : $resource));
+        }
+
+        // TODO: Better recognise image format
+        return imagewebp($resource);
+    }
+}

--- a/src/Filesystem/ImageTransformer/Driver/ImagickDriver.php
+++ b/src/Filesystem/ImageTransformer/Driver/ImagickDriver.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Zenstruck\Filesystem\ImageTransformer\Driver;
+
+use BadMethodCallException;
+use Imagick;
+use ImagickException;
+use Zenstruck\Filesystem\ImageTransformer\Driver;
+use Zenstruck\Filesystem\Node\File\Image;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+class ImagickDriver implements Driver
+{
+    public function __construct()
+    {
+        if (!class_exists(Imagick::class)) {
+            throw new BadMethodCallException("Imagick class in unavailable. Install `ext-imagick` to use this driver.");
+        }
+    }
+
+    /**
+     * @throws ImagickException
+     */
+    public function loadFromImage(Image $image): mixed
+    {
+        $imagick = new Imagick();
+
+        if (!$imagick->readImageBlob($image->contents(), $image->name())) {
+            throw new ImagickException(sprintf("Could not read from image at %s", $image->path()));
+        }
+
+        return $imagick;
+    }
+
+    /**
+     * @throws ImagickException
+     */
+    public function getContents(mixed $resource): mixed
+    {
+        if (!$resource instanceof Imagick) {
+            throw new BadMethodCallException(sprintf("Wrong data type returned from tranformation. %s was expected, got %s", Imagick::class, is_object($resource) ? $resource::class : $resource));
+        }
+
+        return $resource->getImageBlob();
+    }
+}

--- a/src/Filesystem/ImageTransformer/Driver/ImagickDriver.php
+++ b/src/Filesystem/ImageTransformer/Driver/ImagickDriver.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 namespace Zenstruck\Filesystem\ImageTransformer\Driver;
 

--- a/src/Filesystem/ImageTransformer/Driver/InterventionDriver.php
+++ b/src/Filesystem/ImageTransformer/Driver/InterventionDriver.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Zenstruck\Filesystem\ImageTransformer\Driver;
+
+use BadMethodCallException;
+use Intervention\Image\Image as InterventionImage;
+use Intervention\Image\ImageManagerStatic;
+use Zenstruck\Filesystem\ImageTransformer\Driver;
+use Zenstruck\Filesystem\Node\File\Image;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ * TODO: Inject ImageManager
+ */
+class InterventionDriver implements Driver
+{
+    public function loadFromImage(Image $image): InterventionImage
+    {
+        return ImageManagerStatic::make($image->contents());
+    }
+
+    public function getContents(mixed $resource): string
+    {
+        if (!$resource instanceof InterventionImage) {
+            throw new BadMethodCallException(sprintf("Wrong data type returned from tranformation. %s was expected, got %s", InterventionImage::class, is_object($resource) ? $resource::class : $resource));
+        }
+
+        return (string) $resource->encode();
+    }
+}

--- a/src/Filesystem/ImageTransformer/ImageTransformer.php
+++ b/src/Filesystem/ImageTransformer/ImageTransformer.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Zenstruck\Filesystem\ImageTransformer;
+
+use BadMethodCallException;
+use Closure;
+use League\Flysystem\FilesystemException;
+use Zenstruck\Filesystem\Adapter\Operator;
+use Zenstruck\Filesystem\ImageTransformer\Driver\GDDriver;
+use Zenstruck\Filesystem\ImageTransformer\Driver\ImagickDriver;
+use Zenstruck\Filesystem\ImageTransformer\Driver\InterventionDriver;
+use Zenstruck\Filesystem\Node\File\Image;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+final class ImageTransformer
+{
+    private ?Driver $driver = null;
+    private ?Closure $closure = null;
+
+    public function __construct(
+        private Image $image,
+        private Operator $operator
+    ) {
+    }
+
+    public function usingGD(callable $callable): self
+    {
+        $this->ensureUnset();
+
+        $this->driver = new GDDriver();
+        $this->closure = Closure::fromCallable($callable);
+
+        return $this;
+    }
+
+    public function usingImagick(callable $callable): self
+    {
+        $this->ensureUnset();
+
+        $this->driver = new ImagickDriver();
+        $this->closure = Closure::fromCallable($callable);
+
+        return $this;
+    }
+
+    public function usingIntervention(callable $callable): self
+    {
+        $this->ensureUnset();
+
+        $this->driver = new InterventionDriver();
+        $this->closure = Closure::fromCallable($callable);
+
+        return $this;
+    }
+
+    /**
+     * @throws FilesystemException
+     */
+    public function overwrite(): Image
+    {
+        $resource = $this->transform();
+        $this->write($this->image->path(), $resource);
+
+        return $this->image->refresh();
+    }
+
+    /**
+     * @throws FilesystemException
+     */
+    public function saveAs(string $path): Image
+    {
+        $resource = $this->transform();
+        assert($this->driver instanceof Driver);
+
+        $this->write($path, $resource);
+
+        // TODO: Create new Image object for the new path
+        return $this->image->refresh();
+    }
+
+    /**
+     * @throws BadMethodCallException
+     */
+    private function ensureUnset(): void
+    {
+        if (null !== $this->driver || null !== $this->closure) {
+            throw new BadMethodCallException("Transformation is already configured");
+        }
+    }
+
+    /**
+     * @throws BadMethodCallException
+     */
+    private function ensureSet(): void
+    {
+        if (null === $this->driver || null === $this->closure) {
+            throw new BadMethodCallException("Transformation is not configured");
+        }
+    }
+
+    private function transform(): mixed
+    {
+        $this->ensureSet();
+        assert($this->closure instanceof Closure);
+        assert($this->driver instanceof Driver);
+        assert($this->operator instanceof Operator);
+
+        $input = $this->driver->loadFromImage($this->image);
+        return ($this->closure)($input);
+    }
+
+    /**
+     * @throws FilesystemException
+     */
+    private function write(string $path, mixed $resource): void
+    {
+        assert($this->driver instanceof Driver);
+
+        if (is_string($resource)) {
+            $this->operator->write(
+                $path,
+                $resource
+            );
+        } else {
+            $this->operator->writeStream(
+                $path,
+                $resource
+            );
+        }
+    }
+}

--- a/src/Filesystem/Node/File/Image.php
+++ b/src/Filesystem/Node/File/Image.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Filesystem\Node\File;
 
 use League\Flysystem\UnableToRetrieveMetadata;
+use Zenstruck\Filesystem\ImageTransformer\ImageTransformer;
 use Zenstruck\Filesystem\Node\File;
 
 /**
@@ -60,6 +61,14 @@ class Image extends File
         unset($this->imageSize);
 
         return parent::refresh();
+    }
+
+    final public function transform(): ImageTransformer
+    {
+        return new ImageTransformer(
+            $this,
+            $this->operator()
+        );
     }
 
     /**


### PR DESCRIPTION
This is more proof of a concept than actual implementation. I had a bit different approach to image manipulation that I wanted to explore.

The idea is to be able to use any transformer desired in a simple, Closure-based API (somehow like #15 but in a more generic way):

```
/** @var Image $image */
$image->transform()
    ->usingGD(function(GdImage $gd) {
        // Manipulate image
        return $gd;
    })
    // OR
    ->usingImagick(function(Imagick $imagick) {
        // Manipulate image
        return $imagick;
    })
    // OR
    ->usingIntervention(function(\Intervention\Image\Image $image){
        // Manipulate image
        return $image;
    })
    // OR possible others
    
    // Save resulting image
    ->overwrite()
    // OR
    ->saveAs('image.png')
;
```

Both `overwrite` and `saveAs` return `Image`, so we stay within this library objects through the whole process and only use underlying resources/classes in passed closures.

It would allow us to provide wrappers for as many libraries/extensions (VIPS/Imagine etc.) with ease by implementing just 2 methods for each (defined in `Driver` class):
- one that takes the `Image` and returns resource or object associated with the driver
- one that takes the resource or object associated with the driver and returns image string or stream to be saved

As it currently stands there are some DI problems I've encountered, but probably nothing that can't be overcome. Especially given `ImageTransform` object is created within `Image` context, but would benefit greatly from access to the `MultiFilesystem` (to ease taking for example an image from temp filesystem, manipulate it and store in the other).

For now I'd love to hear what do you think about this approach as is it worth investing more time in it? :)