### PR TITLE
FilesystemFileType for simple Sf Form integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.5.0",
         "symfony/expression-language": "^5.4|^6.0",
+        "symfony/form": "^6.1",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/mime": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.5.0",
         "symfony/expression-language": "^5.4|^6.0",
-        "symfony/form": "^6.1",
+        "symfony/form": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/mime": "^5.4|^6.0",
         "symfony/phpunit-bridge": "^6.0",

--- a/src/Filesystem/Bridge/Symfony/DependencyInjection/ZenstruckFilesystemExtension.php
+++ b/src/Filesystem/Bridge/Symfony/DependencyInjection/ZenstruckFilesystemExtension.php
@@ -11,6 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -30,6 +31,7 @@ use Zenstruck\Filesystem\Bridge\Doctrine\Persistence\Namer\SlugifyNamer;
 use Zenstruck\Filesystem\Bridge\Doctrine\Persistence\Namer\TwigNamer;
 use Zenstruck\Filesystem\Bridge\Doctrine\Persistence\NodeConfigProvider;
 use Zenstruck\Filesystem\Bridge\Doctrine\Persistence\ORMNodeConfigProvider;
+use Zenstruck\Filesystem\Bridge\Symfony\Form\Type\FilesystemFileType;
 use Zenstruck\Filesystem\Bridge\Symfony\HttpKernel\FilesystemDataCollector;
 use Zenstruck\Filesystem\Bridge\Symfony\Routing\RouteFileUrlFeature;
 use Zenstruck\Filesystem\Bridge\Symfony\Serializer\NodeNormalizer;
@@ -204,6 +206,13 @@ final class ZenstruckFilesystemExtension extends ConfigurableExtension
 
         if ($config['events']['remove']['enabled']) {
             $subscriber->addTag('doctrine.event_listener', ['event' => 'postRemove']);
+        }
+
+        if (class_exists(FormType::class)) {
+            $container->register(
+                '.zenstruck_filesystem.form.filesystem_file',
+                FilesystemFileType::class
+            );
         }
     }
 

--- a/src/Filesystem/Bridge/Symfony/DependencyInjection/ZenstruckFilesystemExtension.php
+++ b/src/Filesystem/Bridge/Symfony/DependencyInjection/ZenstruckFilesystemExtension.php
@@ -208,7 +208,7 @@ final class ZenstruckFilesystemExtension extends ConfigurableExtension
             $subscriber->addTag('doctrine.event_listener', ['event' => 'postRemove']);
         }
 
-        if (class_exists(FormType::class)) {
+        if (\class_exists(FormType::class)) {
             $container->register(
                 '.zenstruck_filesystem.form.filesystem_file',
                 FilesystemFileType::class

--- a/src/Filesystem/Bridge/Symfony/Form/Type/FilesystemFileType.php
+++ b/src/Filesystem/Bridge/Symfony/Form/Type/FilesystemFileType.php
@@ -22,7 +22,7 @@ class FilesystemFileType extends AbstractType
     {
         $builder->addEventListener(
             FormEvents::PRE_SUBMIT,
-            function (FormEvent $event) use ($options) {
+            function(FormEvent $event) use ($options) {
                 if ($formData = $event->getData()) {
                     if ($options['multiple']) {
                         $data = [];
@@ -37,7 +37,6 @@ class FilesystemFileType extends AbstractType
                             new PendingFile($formData, $options['filesystem_options'])
                         );
                     }
-
                 }
             },
             -10
@@ -47,8 +46,8 @@ class FilesystemFileType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class' => fn (Options $options) => $options['multiple'] ? null : File::class,
-            'filesystem_options' => []
+            'data_class' => fn(Options $options) => $options['multiple'] ? null : File::class,
+            'filesystem_options' => [],
         ]);
 
         $resolver->setAllowedTypes('filesystem_options', 'array');

--- a/src/Filesystem/Bridge/Symfony/Form/Type/FilesystemFileType.php
+++ b/src/Filesystem/Bridge/Symfony/Form/Type/FilesystemFileType.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Zenstruck\Filesystem\Bridge\Symfony\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\File\File as FoundationFile;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Zenstruck\Filesystem\Node\File;
+use Zenstruck\Filesystem\Node\File\PendingFile;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+class FilesystemFileType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->addEventListener(
+            FormEvents::PRE_SUBMIT,
+            function (FormEvent $event) use ($options) {
+                if ($formData = $event->getData()) {
+                    if ($options['multiple']) {
+                        $data = [];
+                        foreach ($formData as $file) {
+                            if ($file instanceof FoundationFile) {
+                                $data[] = new PendingFile($file, $options['filesystem_options']);
+                            }
+                        }
+                        $event->setData($data);
+                    } elseif ($formData instanceof FoundationFile) {
+                        $event->setData(
+                            new PendingFile($formData, $options['filesystem_options'])
+                        );
+                    }
+
+                }
+            },
+            -10
+        );
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => fn (Options $options) => $options['multiple'] ? null : File::class,
+            'filesystem_options' => []
+        ]);
+
+        $resolver->setAllowedTypes('filesystem_options', 'array');
+    }
+
+    public function getParent(): string
+    {
+        return FileType::class;
+    }
+}

--- a/tests/Bridge/Symfony/Form/FilesystemFileTest.php
+++ b/tests/Bridge/Symfony/Form/FilesystemFileTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Zenstruck\Filesystem\Tests\Bridge\Symfony\Form;
+
+use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Zenstruck\Filesystem\Bridge\Symfony\Form\Type\FilesystemFileType;
+use Zenstruck\Filesystem\Node\File\PendingFile;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+class FilesystemFileTest extends TypeTestCase
+{
+    private function testFile(): File
+    {
+        return new File(__DIR__.'/../../../Fixture/files/symfony.png');
+    }
+
+    private function uploadedFile(): UploadedFile
+    {
+        return new UploadedFile(__DIR__.'/../../../Fixture/files/symfony.png', 'symfony.png', null, 0, true);
+    }
+
+    public function testSetData(): void {
+        $form = $this->factory->create(FilesystemFileType::class);
+
+        $data = new PendingFile($this->testFile());
+
+        $form->setData($data);
+
+        self::assertSame($data, $form->getData());
+    }
+
+    public function testSubmit(): void {
+        $requestHandler = new HttpFoundationRequestHandler();
+        $form = $this->factory->createBuilder(FilesystemFileType::class)->setRequestHandler($requestHandler)->getForm();
+        $data = $this->uploadedFile();
+
+        $form->submit($data);
+
+        self::assertInstanceOf(PendingFile::class, $form->getData());
+        $this->assertSame($data->getClientOriginalName(), $form->getData()->originalName());
+    }
+}

--- a/tests/Bridge/Symfony/Form/FilesystemFileTest.php
+++ b/tests/Bridge/Symfony/Form/FilesystemFileTest.php
@@ -14,27 +14,25 @@ use Zenstruck\Filesystem\Node\File\PendingFile;
  */
 class FilesystemFileTest extends TypeTestCase
 {
-    private function testFile(): File
+    /**
+     * @test
+     */
+    public function set_data(): void
     {
-        return new File(__DIR__.'/../../../Fixture/files/symfony.png');
-    }
-
-    private function uploadedFile(): UploadedFile
-    {
-        return new UploadedFile(__DIR__.'/../../../Fixture/files/symfony.png', 'symfony.png', null, 0, true);
-    }
-
-    public function testSetData(): void {
         $form = $this->factory->create(FilesystemFileType::class);
 
-        $data = new PendingFile($this->testFile());
+        $data = new PendingFile($this->file());
 
         $form->setData($data);
 
         self::assertSame($data, $form->getData());
     }
 
-    public function testSubmit(): void {
+    /**
+     * @test
+     */
+    public function submit(): void
+    {
         $requestHandler = new HttpFoundationRequestHandler();
         $form = $this->factory->createBuilder(FilesystemFileType::class)->setRequestHandler($requestHandler)->getForm();
         $data = $this->uploadedFile();
@@ -43,5 +41,15 @@ class FilesystemFileTest extends TypeTestCase
 
         self::assertInstanceOf(PendingFile::class, $form->getData());
         $this->assertSame($data->getClientOriginalName(), $form->getData()->originalName());
+    }
+
+    private function file(): File
+    {
+        return new File(__DIR__.'/../../../Fixture/files/symfony.png');
+    }
+
+    private function uploadedFile(): UploadedFile
+    {
+        return new UploadedFile(__DIR__.'/../../../Fixture/files/symfony.png', 'symfony.png', null, 0, true);
     }
 }


### PR DESCRIPTION
This one adds very simple `FilesystemFileType` built on top of core `FileType`. It's main purpose it transforming `UploadedFile` objects from `FileType` into `PendingFile`.

The tests are very simple right now as TBH I probably lack a bit of form component expertise to determine all possible paths - help very welcome, I'd love to learn :)

For now the only purpose of this type is to plumber between `FileType`. My intent is to similarly provide `FilesystemImageType` (based on `ImageType`), whenever `PendingImage` (or similar) will be merged.